### PR TITLE
Specify truffle version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ RUN echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.lis
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
 RUN apt-get update
 RUN apt-get install -y nodejs sbt make g++
-RUN npm install -g truffle ganache-cli
+RUN npm install -g truffle@4.1.14 ganache-cli


### PR DESCRIPTION
Stops the impending blowup when truffle v5 is released later this week